### PR TITLE
Implements the device delete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ import (
 )
 
 func main() {
-	apiKey := os.GetEnv("TAILSCALE_API_KEY")
-	tailnet := os.GetEnv("TAILSCALE_TAILNET")
+	apiKey := os.Getenv("TAILSCALE_API_KEY")
+	tailnet := os.Getenv("TAILSCALE_TAILNET")
 
 	client, err := tailscale.NewClient(apiKey, tailnet)
 	if err != nil {

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -386,6 +386,19 @@ func (c *Client) AuthorizeDevice(ctx context.Context, deviceID string) error {
 	return c.performRequest(req, nil)
 }
 
+// DeleteDevice deletes the device given its deviceID.
+func (c *Client) DeleteDevice(ctx context.Context, deviceID string) error {
+	const uriFmt = "/api/v2/device/%s"
+	req, err := c.buildRequest(ctx, http.MethodDelete, fmt.Sprintf(uriFmt, deviceID), map[string]bool{
+		"authorized": true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.performRequest(req, nil)
+}
+
 type (
 	// The KeyCapabilities type describes the capabilities of an authentication key.
 	KeyCapabilities struct {

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -389,9 +389,7 @@ func (c *Client) AuthorizeDevice(ctx context.Context, deviceID string) error {
 // DeleteDevice deletes the device given its deviceID.
 func (c *Client) DeleteDevice(ctx context.Context, deviceID string) error {
 	const uriFmt = "/api/v2/device/%s"
-	req, err := c.buildRequest(ctx, http.MethodDelete, fmt.Sprintf(uriFmt, deviceID), map[string]bool{
-		"authorized": true,
-	})
+	req, err := c.buildRequest(ctx, http.MethodDelete, fmt.Sprintf(uriFmt, deviceID), nil)
 	if err != nil {
 		return err
 	}

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -295,9 +295,8 @@ func TestClient_DeleteDevice(t *testing.T) {
 	server.ResponseCode = http.StatusOK
 	ctx := context.Background()
 
-	deviceId := "deviceTestId"
-	err := client.DeleteDevice(ctx, deviceId)
-	assert.NoError(t, err)
+	deviceID := "deviceTestId"
+	assert.NoError(t, client.DeleteDevice(ctx, deviceID))
 	assert.Equal(t, http.MethodDelete, server.Method)
 	assert.Equal(t, "/api/v2/device/deviceTestId", server.Path)
 }

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -286,7 +286,20 @@ func TestClient_Devices(t *testing.T) {
 	assert.Equal(t, http.MethodGet, server.Method)
 	assert.Equal(t, "/api/v2/tailnet/example.com/devices", server.Path)
 	assert.EqualValues(t, expectedDevices["devices"], actualDevices)
+}
 
+func TestClient_DeleteDevice(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+	ctx := context.Background()
+
+	deviceId := "deviceTestId"
+	err := client.DeleteDevice(ctx, deviceId)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, server.Method)
+	assert.Equal(t, "/api/v2/device/deviceTestId", server.Path)
 }
 
 func TestClient_DeviceSubnetRoutes(t *testing.T) {


### PR DESCRIPTION
Added support for deleting devices using the go client. Needed as I want to add support for removing devices in the terraform provider as another user requested [here](https://github.com/davidsbond/terraform-provider-tailscale/issues/68)

This commit adds the capability of deleting devices based on their IDs.