### PR TITLE
Add SetDeviceTags method

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -450,6 +450,20 @@ func (c *Client) DeleteKey(ctx context.Context, id string) error {
 	return c.performRequest(req, nil)
 }
 
+// SetDeviceTags updates the tags of a target device.
+func (c *Client) SetDeviceTags(ctx context.Context, deviceID string, tags []string) error {
+	const uriFmt = "/api/v2/device/%s/tags"
+
+	req, err := c.buildRequest(ctx, http.MethodPost, fmt.Sprintf(uriFmt, deviceID), map[string][]string{
+		"tags": tags,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.performRequest(req, nil)
+}
+
 // IsNotFound returns true if the provided error implementation is an APIError with a status of 404.
 func IsNotFound(err error) bool {
 	var apiErr APIError

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -507,3 +507,21 @@ func TestIsNotFound(t *testing.T) {
 	_, err := client.GetKey(context.Background(), "test")
 	assert.True(t, tailscale.IsNotFound(err))
 }
+
+func TestClient_SetDeviceTags(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	const deviceID = "test"
+	tags := []string{"a:b", "b:c"}
+
+	assert.NoError(t, client.SetDeviceTags(context.Background(), deviceID, tags))
+	assert.EqualValues(t, http.MethodPost, server.Method)
+	assert.EqualValues(t, "/api/v2/device/"+deviceID+"/tags", server.Path)
+
+	body := make(map[string][]string)
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &body))
+	assert.EqualValues(t, tags, body["tags"])
+}


### PR DESCRIPTION
This commit introduces the `SetDeviceTags` methods which allows for setting the tags of a specified
device. See the [API documentation](https://github.com/tailscale/tailscale/blob/main/api.md#device-tags-post) for full details.

Signed-off-by: David Bond <davidsbond93@gmail.com>