### PR TITLE
Expose tags field on Device

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -353,6 +353,7 @@ type Device struct {
 	ID         string   `json:"id"`
 	Authorized bool     `json:"authorized"`
 	User       string   `json:"user"`
+	Tags       []string `json:"tags"`
 }
 
 // Devices lists the devices in a tailnet.


### PR DESCRIPTION
This commit adds the exported `Tags` field to the `Device` type which the API returns when a device
has any tags set.

Signed-off-by: David Bond <davidsbond93@gmail.com>