### PR TITLE
Add Data field to api errors

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -25,8 +25,15 @@ type (
 
 	// The APIError type describes an error as returned by the Tailscale API.
 	APIError struct {
-		Message string `json:"message"`
+		Message string         `json:"message"`
+		Data    []APIErrorData `json:"data"`
 		status  int
+	}
+
+	// The APIErrorData type describes elements of the data field within errors returned by the Tailscale API.
+	APIErrorData struct {
+		User   string   `json:"user"`
+		Errors []string `json:"errors"`
 	}
 
 	// The ClientOption type is a function that is used to modify a Client.
@@ -484,4 +491,15 @@ func IsNotFound(err error) bool {
 	}
 
 	return false
+}
+
+// ErrorData returns the contents of the APIError.Data field from the provided error if it is of type APIError. Returns
+// a nil slice if the given error is not of type APIError.
+func ErrorData(err error) []APIErrorData {
+	var apiErr APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Data
+	}
+
+	return nil
 }


### PR DESCRIPTION
Closes #5

This commit adds the `Data` field to the `APIError` type and provides a helper function `ErrorData` to obtain
the slice of errors from the response. This will allow us to expose errors in ACL tests.

Signed-off-by: David Bond <davidsbond93@gmail.com>