### PR TITLE
Add SetDeviceKey method to client

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -483,6 +483,27 @@ func (c *Client) SetDeviceTags(ctx context.Context, deviceID string, tags []stri
 	return c.performRequest(req, nil)
 }
 
+type (
+	// The DeviceKey type represents the properties of the key of an individual device within
+	// the tailnet.
+	DeviceKey struct {
+		KeyExpiryDisabled bool `json:"keyExpiryDisabled"` // Whether or not this device's key will ever expire.
+		Preauthorized     bool `json:"preauthorized"`     // Whether or not this device is pre-authorized for the tailnet.
+	}
+)
+
+// SetDeviceKey updates the properties of a device's key.
+func (c *Client) SetDeviceKey(ctx context.Context, deviceID string, key DeviceKey) error {
+	const uriFmt = "/api/v2/device/%s/key"
+
+	req, err := c.buildRequest(ctx, http.MethodPost, fmt.Sprintf(uriFmt, deviceID), key)
+	if err != nil {
+		return err
+	}
+
+	return c.performRequest(req, nil)
+}
+
 // IsNotFound returns true if the provided error implementation is an APIError with a status of 404.
 func IsNotFound(err error) bool {
 	var apiErr APIError

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -539,6 +539,29 @@ func TestClient_SetDeviceTags(t *testing.T) {
 	assert.EqualValues(t, tags, body["tags"])
 }
 
+func TestClient_SetDeviceKey(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	const deviceID = "test"
+	expected := tailscale.DeviceKey{
+		KeyExpiryDisabled: true,
+		Preauthorized:     true,
+	}
+
+	assert.NoError(t, client.SetDeviceKey(context.Background(), deviceID, expected))
+
+	assert.EqualValues(t, http.MethodPost, server.Method)
+	assert.EqualValues(t, "/api/v2/device/"+deviceID+"/key", server.Path)
+
+	var actual tailscale.DeviceKey
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actual))
+	assert.EqualValues(t, expected, actual)
+
+}
+
 func TestErrorData(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #7

This commit adds the `SetDeviceKey` method to the `Client` type which can be used to configure the
properties of a device key.

Signed-off-by: David Bond <davidsbond93@gmail.com>