### PR TITLE
Add KeyExpiryDisabled field to Device

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -355,12 +355,13 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 }
 
 type Device struct {
-	Addresses  []string `json:"addresses"`
-	Name       string   `json:"name"`
-	ID         string   `json:"id"`
-	Authorized bool     `json:"authorized"`
-	User       string   `json:"user"`
-	Tags       []string `json:"tags"`
+	Addresses         []string `json:"addresses"`
+	Name              string   `json:"name"`
+	ID                string   `json:"id"`
+	Authorized        bool     `json:"authorized"`
+	User              string   `json:"user"`
+	Tags              []string `json:"tags"`
+	KeyExpiryDisabled bool     `json:"keyExpiryDisabled"`
 }
 
 // Devices lists the devices in a tailnet.

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -272,8 +272,15 @@ func TestClient_Devices(t *testing.T) {
 	expectedDevices := map[string][]tailscale.Device{
 		"devices": {
 			{
-				Name: "test",
-				ID:   "test",
+				Addresses:         []string{"127.0.0.1"},
+				Name:              "test",
+				ID:                "test",
+				Authorized:        true,
+				KeyExpiryDisabled: true,
+				User:              "test@example.com",
+				Tags: []string{
+					"tag:value",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This commit adds the `KeyExpiryDisabled` boolean field to the `Device` type. This field indicates that a device
key has been configured to never expire.

This field is required for https://github.com/davidsbond/terraform-provider-tailscale/issues/78 on the terraform
provider so that we can perform a read on the device to determine the existing properties of a device key.

Signed-off-by: David Bond <davidsbond93@gmail.com>