### PR TITLE
Expose more fields on Device

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -355,13 +355,24 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 }
 
 type Device struct {
-	Addresses         []string `json:"addresses"`
-	Name              string   `json:"name"`
-	ID                string   `json:"id"`
-	Authorized        bool     `json:"authorized"`
-	User              string   `json:"user"`
-	Tags              []string `json:"tags"`
-	KeyExpiryDisabled bool     `json:"keyExpiryDisabled"`
+	Addresses                 []string  `json:"addresses"`
+	Name                      string    `json:"name"`
+	ID                        string    `json:"id"`
+	Authorized                bool      `json:"authorized"`
+	User                      string    `json:"user"`
+	Tags                      []string  `json:"tags"`
+	KeyExpiryDisabled         bool      `json:"keyExpiryDisabled"`
+	BlocksIncomingConnections bool      `json:"blocksIncomingConnections"`
+	ClientVersion             string    `json:"clientVersion"`
+	Created                   time.Time `json:"created"`
+	Expires                   time.Time `json:"expires"`
+	Hostname                  string    `json:"hostname"`
+	IsExternal                bool      `json:"isExternal"`
+	LastSeen                  time.Time `json:"lastSeen"`
+	MachineKey                string    `json:"machineKey"`
+	NodeKey                   string    `json:"nodeKey"`
+	OS                        string    `json:"os"`
+	UpdateAvailable           bool      `json:"updateAvailable"`
 }
 
 // Devices lists the devices in a tailnet.

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -281,6 +281,17 @@ func TestClient_Devices(t *testing.T) {
 				Tags: []string{
 					"tag:value",
 				},
+				BlocksIncomingConnections: false,
+				ClientVersion:             "1.22.1",
+				Created:                   time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC),
+				Expires:                   time.Date(2022, 8, 9, 11, 50, 23, 0, time.UTC),
+				Hostname:                  "test",
+				IsExternal:                false,
+				LastSeen:                  time.Date(2022, 3, 9, 20, 3, 42, 0, time.UTC),
+				MachineKey:                "mkey:test",
+				NodeKey:                   "nodekey:test",
+				OS:                        "windows",
+				UpdateAvailable:           true,
 			},
 		},
 	}


### PR DESCRIPTION
First of all, thank you so much for developing the handy library!
This PR adds some exported fields to the `Device` type. It will allow us to collect device-related metrics and manage devices using this client library. Several use-cases in my mind are:
- Collect `ClientVersion` to warn those who use an outdated client.
- Collect `LastSeen` to delete a device not seen in the past N days.
