### PR TITLE
fix: allow for parsing json parsing when timestamps are empty

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -361,7 +361,7 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 }
 
 // MaybeEmptyTime wraps a time and allows for unmarshalling timestamps that represent an empty time as an empty string (e.g "")
-// this is used by the tailscale API when it returns services that have no created date, such as it's hello service.
+// this is used by the tailscale API when it returns devices that have no created date, such as its hello service.
 type MaybeEmptyTime struct {
 	time.Time
 }
@@ -371,9 +371,9 @@ func (t MaybeEmptyTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time)
 }
 
-// MarshalJSON returns nil if it is a blank string, otherwise, returns the result of json.Unmarshal.
+// MarshalJSON unmarshals the content of data as a time.Duration, a blank string will keep the time at its zero value.
 func (t *MaybeEmptyTime) UnmarshalJSON(data []byte) error {
-	if string(data) == "\"\"" {
+	if string(data) == `""` {
 		return nil
 	}
 

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -360,19 +360,19 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 	return &resp, nil
 }
 
-// MaybeEmptyTime wraps a time and allows for unmarshalling timestamps that represent an empty time as an empty string (e.g "")
+// Time wraps a time and allows for unmarshalling timestamps that represent an empty time as an empty string (e.g "")
 // this is used by the tailscale API when it returns devices that have no created date, such as its hello service.
-type MaybeEmptyTime struct {
+type Time struct {
 	time.Time
 }
 
 // MarshalJSON is an implementation of json.Marshal.
-func (t MaybeEmptyTime) MarshalJSON() ([]byte, error) {
+func (t Time) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time)
 }
 
 // MarshalJSON unmarshals the content of data as a time.Duration, a blank string will keep the time at its zero value.
-func (t *MaybeEmptyTime) UnmarshalJSON(data []byte) error {
+func (t *Time) UnmarshalJSON(data []byte) error {
 	if string(data) == `""` {
 		return nil
 	}
@@ -394,11 +394,11 @@ type Device struct {
 	KeyExpiryDisabled         bool           `json:"keyExpiryDisabled"`
 	BlocksIncomingConnections bool           `json:"blocksIncomingConnections"`
 	ClientVersion             string         `json:"clientVersion"`
-	Created                   MaybeEmptyTime `json:"created"`
-	Expires                   MaybeEmptyTime `json:"expires"`
+	Created                   Time `json:"created"`
+	Expires                   Time `json:"expires"`
 	Hostname                  string         `json:"hostname"`
 	IsExternal                bool           `json:"isExternal"`
-	LastSeen                  MaybeEmptyTime `json:"lastSeen"`
+	LastSeen                  Time `json:"lastSeen"`
 	MachineKey                string         `json:"machineKey"`
 	NodeKey                   string         `json:"nodeKey"`
 	OS                        string         `json:"os"`

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -309,11 +309,11 @@ func TestClient_Devices(t *testing.T) {
 				},
 				BlocksIncomingConnections: false,
 				ClientVersion:             "1.22.1",
-				Created:                   tailscale.MaybeEmptyTime{time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
-				Expires:                   tailscale.MaybeEmptyTime{time.Date(2022, 8, 9, 11, 50, 23, 0, time.UTC)},
+				Created:                   tailscale.Time{time.Date(2022, 2, 10, 11, 50, 23, 0, time.UTC)},
+				Expires:                   tailscale.Time{time.Date(2022, 8, 9, 11, 50, 23, 0, time.UTC)},
 				Hostname:                  "test",
 				IsExternal:                false,
-				LastSeen:                  tailscale.MaybeEmptyTime{time.Date(2022, 3, 9, 20, 3, 42, 0, time.UTC)},
+				LastSeen:                  tailscale.Time{time.Date(2022, 3, 9, 20, 3, 42, 0, time.UTC)},
 				MachineKey:                "mkey:test",
 				NodeKey:                   "nodekey:test",
 				OS:                        "windows",
@@ -352,15 +352,15 @@ func TestDevices_Unmarshal(t *testing.T) {
 					Authorized:                true,
 					BlocksIncomingConnections: false,
 					ClientVersion:             "",
-					Created:                   tailscale.MaybeEmptyTime{},
-					Expires: tailscale.MaybeEmptyTime{
+					Created:                   tailscale.Time{},
+					Expires: tailscale.Time{
 						time.Date(1, 1, 1, 00, 00, 00, 0, time.UTC),
 					},
 					Hostname:          "hello",
 					ID:                "50052",
 					IsExternal:        true,
 					KeyExpiryDisabled: true,
-					LastSeen: tailscale.MaybeEmptyTime{
+					LastSeen: tailscale.Time{
 						time.Date(2022, 4, 15, 13, 24, 40, 0, time.UTC),
 					},
 					MachineKey:      "",
@@ -375,17 +375,17 @@ func TestDevices_Unmarshal(t *testing.T) {
 					Authorized:                true,
 					BlocksIncomingConnections: false,
 					ClientVersion:             "1.22.2-t60b671955-gecc5d9846",
-					Created: tailscale.MaybeEmptyTime{
+					Created: tailscale.Time{
 						time.Date(2022, 3, 5, 17, 10, 27, 0, time.UTC),
 					},
-					Expires: tailscale.MaybeEmptyTime{
+					Expires: tailscale.Time{
 						time.Date(2022, 9, 1, 17, 10, 27, 0, time.UTC),
 					},
 					Hostname:          "foo",
 					ID:                "50053",
 					IsExternal:        false,
 					KeyExpiryDisabled: true,
-					LastSeen: tailscale.MaybeEmptyTime{
+					LastSeen: tailscale.Time{
 						time.Date(2022, 4, 15, 13, 25, 21, 0, time.UTC),
 					},
 					MachineKey:      "mkey:30dc3c061ac8b33fdc6d88a4a67b053b01b56930d78cae0cf7a164411d424c0d",

--- a/tailscale/maybe_empty_time_test.go
+++ b/tailscale/maybe_empty_time_test.go
@@ -1,0 +1,57 @@
+package tailscale_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapsStdTime(t *testing.T) {
+	expectedTime := tailscale.MaybeEmptyTime{}
+	newTime := time.Time{}
+	assert.Equal(t, expectedTime.Time.UTC(), newTime.UTC())
+}
+
+func TestFailsToParseInvalidTimestamps(t *testing.T) {
+	ti := tailscale.MaybeEmptyTime{}
+	invalidIso8601Date := []byte("\"2022-13-05T17:10:27Z\"")
+	assert.Error(t, ti.UnmarshalJSON(invalidIso8601Date))
+}
+
+func TestMarshalingMaybeEmptyTimestamps(t *testing.T) {
+	t.Parallel()
+	utcMinusFour := time.FixedZone("UTC-4", -60*60*4)
+
+	tt := []struct {
+		Name        string
+		Expected    time.Time
+		TimeContent string
+	}{
+		{
+			Name:        "It should handle empty strings as null-value times",
+			Expected:    time.Time{},
+			TimeContent: "\"\"",
+		},
+		{
+			Name:        "It should parse timestamp strings",
+			Expected:    time.Date(2022, 3, 5, 17, 10, 27, 0, time.UTC),
+			TimeContent: "\"2022-03-05T17:10:27Z\"",
+		},
+		{
+			Name:        "It should handle different timezones",
+			TimeContent: "\"2006-01-02T15:04:05-04:00\"",
+			Expected:    time.Date(2006, 1, 2, 15, 04, 5, 0, utcMinusFour),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual := tailscale.MaybeEmptyTime{}
+
+			assert.NoError(t, actual.UnmarshalJSON([]byte(tc.TimeContent)))
+			assert.Equal(t, tc.Expected.UTC(), actual.Time.UTC())
+		})
+	}
+}

--- a/tailscale/testdata/devices.json
+++ b/tailscale/testdata/devices.json
@@ -1,0 +1,48 @@
+{
+  "devices": [
+    {
+      "addresses": [
+        "100.101.102.103",
+        "fd7a:115c:a1e0:ab12:4843:cd96:6265:6667"
+      ],
+      "authorized": true,
+      "blocksIncomingConnections": false,
+      "clientVersion": "",
+      "created": "",
+      "expires": "0001-01-01T00:00:00Z",
+      "hostname": "hello",
+      "id": "50052",
+      "isExternal": true,
+      "keyExpiryDisabled": true,
+      "lastSeen": "2022-04-15T13:24:40Z",
+      "machineKey": "",
+      "name": "hello.tailscale.com",
+      "nodeKey": "nodekey:30dc3c061ac8b33fdc6d88a4a67b053b01b56930d78cae0cf7a164411d424c0d",
+      "os": "linux",
+      "updateAvailable": false,
+      "user": "services@tailscale.com"
+    },
+    {
+      "addresses": [
+        "100.121.200.21",
+        "fd7a:115c:a1e0:ab12:4843:cd96:6265:e618"
+      ],
+      "authorized": true,
+      "blocksIncomingConnections": false,
+      "clientVersion": "1.22.2-t60b671955-gecc5d9846",
+      "created": "2022-03-05T17:10:27Z",
+      "expires": "2022-09-01T17:10:27Z",
+      "hostname": "foo",
+      "id": "50053",
+      "isExternal": false,
+      "keyExpiryDisabled": true,
+      "lastSeen": "2022-04-15T13:25:21Z",
+      "machineKey": "mkey:30dc3c061ac8b33fdc6d88a4a67b053b01b56930d78cae0cf7a164411d424c0d",
+      "name": "foo.example.com",
+      "nodeKey": "nodekey:30dc3c061ac8b33fdc6d88a4a67b053b01b56930d78cae0cf7a164411d424c0d",
+      "os": "linux",
+      "updateAvailable": false,
+      "user": "foo@example.com"
+    }
+  ]
+}

--- a/tailscale/time_test.go
+++ b/tailscale/time_test.go
@@ -9,18 +9,18 @@ import (
 )
 
 func TestWrapsStdTime(t *testing.T) {
-	expectedTime := tailscale.MaybeEmptyTime{}
+	expectedTime := tailscale.Time{}
 	newTime := time.Time{}
 	assert.Equal(t, expectedTime.Time.UTC(), newTime.UTC())
 }
 
 func TestFailsToParseInvalidTimestamps(t *testing.T) {
-	ti := tailscale.MaybeEmptyTime{}
+	ti := tailscale.Time{}
 	invalidIso8601Date := []byte("\"2022-13-05T17:10:27Z\"")
 	assert.Error(t, ti.UnmarshalJSON(invalidIso8601Date))
 }
 
-func TestMarshalingMaybeEmptyTimestamps(t *testing.T) {
+func TestMarshalingTimestamps(t *testing.T) {
 	t.Parallel()
 	utcMinusFour := time.FixedZone("UTC-4", -60*60*4)
 
@@ -48,7 +48,7 @@ func TestMarshalingMaybeEmptyTimestamps(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			actual := tailscale.MaybeEmptyTime{}
+			actual := tailscale.Time{}
 
 			assert.NoError(t, actual.UnmarshalJSON([]byte(tc.TimeContent)))
 			assert.Equal(t, tc.Expected.UTC(), actual.Time.UTC())


### PR DESCRIPTION
The Tailscale API returns blank strings for non-existing timestamps, such as the "created" timestamp for Tailscale managed devices. One example is the "hello" device that is returned in the [get devices endpoint](https://github.com/tailscale/tailscale/blob/main/api.md#tailnet-devices-get). 

This will introduce a new struct called `MaybeEmptyTime` which wraps stdlib's `time.Time` struct and is able to Unmarshal Tailscale's representation of a missing timestamp.