### PR TITLE
Move preauthorized to tailnet key

### DIFF
--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -470,9 +470,10 @@ type (
 	KeyCapabilities struct {
 		Devices struct {
 			Create struct {
-				Reusable  bool     `json:"reusable"`
-				Ephemeral bool     `json:"ephemeral"`
-				Tags      []string `json:"tags"`
+				Reusable      bool     `json:"reusable"`
+				Ephemeral     bool     `json:"ephemeral"`
+				Tags          []string `json:"tags"`
+				Preauthorized bool     `json:"preauthorized"`
 			} `json:"create"`
 		} `json:"devices"`
 	}
@@ -548,7 +549,6 @@ type (
 	// the tailnet.
 	DeviceKey struct {
 		KeyExpiryDisabled bool `json:"keyExpiryDisabled"` // Whether or not this device's key will ever expire.
-		Preauthorized     bool `json:"preauthorized"`     // Whether or not this device is pre-authorized for the tailnet.
 	}
 )
 

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -579,6 +579,8 @@ func TestClient_CreateKey(t *testing.T) {
 	capabilities := tailscale.KeyCapabilities{}
 	capabilities.Devices.Create.Ephemeral = true
 	capabilities.Devices.Create.Reusable = true
+	capabilities.Devices.Create.Preauthorized = true
+	capabilities.Devices.Create.Tags = []string{"test:test"}
 
 	expected := tailscale.Key{
 		ID:           "test",
@@ -606,6 +608,8 @@ func TestClient_GetKey(t *testing.T) {
 	capabilities := tailscale.KeyCapabilities{}
 	capabilities.Devices.Create.Ephemeral = true
 	capabilities.Devices.Create.Reusable = true
+	capabilities.Devices.Create.Preauthorized = true
+	capabilities.Devices.Create.Tags = []string{"test:test"}
 
 	expected := tailscale.Key{
 		ID:           "test",
@@ -674,7 +678,6 @@ func TestClient_SetDeviceKey(t *testing.T) {
 	const deviceID = "test"
 	expected := tailscale.DeviceKey{
 		KeyExpiryDisabled: true,
-		Preauthorized:     true,
 	}
 
 	assert.NoError(t, client.SetDeviceKey(context.Background(), deviceID, expected))


### PR DESCRIPTION
This commit moves the Preauthorized field from the device key to the tailnet
key. This was originally a mistake in the tailscale documentation, the field
would have never worked on the device key.

Related to https://github.com/davidsbond/terraform-provider-tailscale/issues/111

Signed-off-by: David Bond <davidsbond93@gmail.com>