### PR TITLE
Do not attempt to standardise response bodies when we don't need to

### DIFF
--- a/tailscale/tailscale_test.go
+++ b/tailscale/tailscale_test.go
@@ -67,5 +67,7 @@ func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	assert.NoError(t.t, err)
 
 	w.WriteHeader(t.ResponseCode)
-	assert.NoError(t.t, json.NewEncoder(w).Encode(t.ResponseBody))
+	if t.ResponseBody != nil {
+		assert.NoError(t.t, json.NewEncoder(w).Encode(t.ResponseBody))
+	}
 }


### PR DESCRIPTION
Related to https://github.com/davidsbond/terraform-provider-tailscale/issues/113

This commit modifies the request making code to not attempt to standardise
response bodies if we are not attempting to parse the response. For example, the
tailnet key delete API response has an empty body, which would cause errors when
calling hujson.Standardize.

Signed-off-by: David Bond <davidsbond93@gmail.com>